### PR TITLE
docs: rename H1 to MobilityDeck after the repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MobilityDB-Deck
+# MobilityDeck
 Integration of MobilityDB with the data visualization framework Deck.gl
 
 ![trips_white](https://user-images.githubusercontent.com/26899974/147404223-af4fd3cb-bec3-4a0b-a1a2-6fe90368bab8.gif)


### PR DESCRIPTION
Following the rename of `MobilityDB/MobilityDB-Deck` → `MobilityDB/MobilityDeck` on 2026-05-01, this updates the README's top heading to match the canonical name.